### PR TITLE
Move "data-js-lang" attr to "lang" on the html tag

### DIFF
--- a/Template/layout.php
+++ b/Template/layout.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<?= $this->app->jsLang() ?>">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
@@ -56,7 +56,6 @@
           data-login-url="<?= $this->url->href('AuthController', 'login') ?>"
           data-keyboard-shortcut-url="<?= $this->url->href('DocumentationController', 'shortcuts') ?>"
           data-timezone="<?= $this->app->getTimezone() ?>"
-          data-js-lang="<?= $this->app->jsLang() ?>"
           data-js-date-format="<?= $this->app->getJsDateFormat() ?>"
           data-js-time-format="<?= $this->app->getJsTimeFormat() ?>"
           data-js-modal-close-msg="<?= t('Close window?\\n\\nChanges that you made have not been saved.') ?>"


### PR DESCRIPTION
This is related to to an issue with the date picker:
https://github.com/creecros/Customizer/issues/100
https://github.com/kanboard/kanboard/commit/e65045f9341361cde730fce14b0b7e273eae7f15
https://github.com/kanboard/kanboard/issues/4335

Without the fix:
![image](https://user-images.githubusercontent.com/8581955/72968275-73dcf900-3dc3-11ea-9858-cf775d11fe3c.png)

After `$('html').attr('lang', $('body').data('js-lang'));`:
![image](https://user-images.githubusercontent.com/8581955/72968382-a7b81e80-3dc3-11ea-8f2b-06e24b911b61.png)
