### PR TITLE
Fixes an issue reported in base kanboard where dragging task cards is sometimes interpreted as a click to open tasks

### DIFF
--- a/Assets/css/moon.css
+++ b/Assets/css/moon.css
@@ -2429,7 +2429,6 @@ div.draggable-item-selected {
     margin-bottom: 8px;
     padding: 12px;
     border-radius: 3px;
-    border: none;
     border-radius: 3px;
     border-bottom: 5px solid;
 }


### PR DESCRIPTION
I have no idea why the "border: none" attribute causes this behavior, but if someone ever figures out please let me know

from https://github.com/kanboard/kanboard/issues/4412